### PR TITLE
Update app.json to SDK30

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
     "description": "A playlist of some songs that Greg likes to demo the Expo AV API.",
     "slug": "playlist",
     "privacy": "public",
-    "sdkVersion": "29.0.0",
+    "sdkVersion": "30.0.0",
     "version": "3.0.0",
     "orientation": "portrait",
     "primaryColor": "#cccccc",


### PR DESCRIPTION
I've been bringing an ejected expo project that uses AV up to SDK 30, based on this sample. Noticed the upgrade instructions include updating SDK version in app.json and thought I'd make the small PR to the sample since I was looking at it.
https://blog.expo.io/expo-sdk-30-0-0-is-now-available-e64d8b1db2a7 